### PR TITLE
Missing required modules 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,8 @@ RUN apt-get install -y hugo nodejs npm
 
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
-RUN npm -g install gulp-cli
+RUN npm -g install gulp-cli gulp-postcss postcss-import postcss-cssnext cssnano
 
 RUN mkdir /asturiashacking
 WORKDIR /asturiashacking
 ADD . /asturiashacking
-
-RUN npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   web:
     build: .
-    command: bash -c "npm link gulp gulp-postcss postcss-import postcss-cssnext cssnano && gulp server"
+    command: bash -c "npm link gulp gulp-postcss postcss-import postcss-cssnext cssnano && gulp css && gulp server"
     ports:
       - "1313:1313"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   web:
     build: .
-    command: gulp server
+    command: bash -c "npm link gulp gulp-postcss postcss-import postcss-cssnext cssnano && gulp server"
     ports:
       - "1313:1313"
     volumes:


### PR DESCRIPTION
`RUN npm install` was installing the dependencies in /asturiashacking/node_modules directory, but /asturiashacking was overriden by the volume defined in docker-compose.yml, so node_modules directory was missing when launching `gulp server`

Required modules are now linked locally, using `npm link` command in the docker-compose.yml

This should fix #4 

